### PR TITLE
Track Stats if Counter is Available [Resolves #10]

### DIFF
--- a/skills_utils/job_posting_import.py
+++ b/skills_utils/job_posting_import.py
@@ -18,7 +18,14 @@ class JobPostingImportBase(object):
         self.s3_conn = s3_conn
         self.onet_cache = onet_cache
 
-    def postings(self, quarter):
+    def postings(self, quarter, stats_counter=None):
+        """Yield job postings in common schema format
+
+        Args:
+            quarter (str) The quarter, in format '2015Q1'
+            stats_counter (object, optional) A counter that can track both
+                input and output documents using a 'track' method.
+        """
         logging.info('Finding postings for %s', quarter)
         for posting in self._iter_postings(quarter):
             transformed = self._transform(posting)
@@ -26,6 +33,11 @@ class JobPostingImportBase(object):
                 self.partner_id,
                 self._id(posting)
             )
+            if stats_counter:
+                stats_counter.track(
+                    input_document=posting,
+                    output_document=transformed
+                )
             yield transformed
 
     def _id(self, document):

--- a/tests/test_job_posting_import.py
+++ b/tests/test_job_posting_import.py
@@ -1,1 +1,34 @@
 from skills_utils.testing import ImporterTest
+from skills_utils import JobPostingImportBase
+from unittest.mock import MagicMock, call
+
+
+class PopulatedImporter(JobPostingImportBase):
+    """A basic importer that can be run through the ImporterTest"""
+    def _iter_postings(self, quarter):
+        return [
+            {'one': 'two'},
+            {'one': 'four'},
+        ]
+
+    def _transform(self, document):
+        transformed = {'title': document['one']}
+        return transformed
+
+    def _id(self, document):
+        return document['one']
+
+
+def test_tracker():
+    """Ensure that the tracker is called"""
+    importer = PopulatedImporter(partner_id='xx')
+    tracker = MagicMock()
+    postings = importer.postings('2015Q1', stats_counter=tracker)
+    assert list(postings) == [
+        {'id': 'xx_two', 'title': 'two'},
+        {'id': 'xx_four', 'title': 'four'}
+    ]
+    tracker.track.assert_has_calls([
+        call(input_document={'one': 'two'}, output_document={'id': 'xx_two', 'title': 'two'}),
+        call(input_document={'one': 'four'}, output_document={'id': 'xx_four', 'title': 'four'}),
+    ])


### PR DESCRIPTION
- In JobPostingImport#postings, optionally receive a counter object and track input and output documents if present